### PR TITLE
Issue 109 mt tailer interruptions

### DIFF
--- a/src/IntegrationTests/LogsearchShipper.exe.config.HeaderlineTest
+++ b/src/IntegrationTests/LogsearchShipper.exe.config.HeaderlineTest
@@ -13,7 +13,7 @@
   </configSections>
 
   <LogSearchShipperGroup>
-    <LogSearchShipper data_folder="data" ingestor_host="ingestor.meta.logsearch.io" ingestor_port="443" output_file="test.out">
+    <LogSearchShipper data_folder="data" ingestor_host="ingestor.meta.logsearch.io" ingestor_port="443" output_file="TestOut.log">
       <fileWatchers>
         <watch files="..\Logs\Log4netTest.txt" type="plain" readFromLast="false" multilineRule="multiline_ci_log4net">
           <field key="environment" value="LogSearchShipper.HeaderlineTest" />

--- a/src/IntegrationTests/LogsearchShipper.exe.config.MtTailerTest
+++ b/src/IntegrationTests/LogsearchShipper.exe.config.MtTailerTest
@@ -13,7 +13,7 @@
   </configSections>
 
   <LogSearchShipperGroup>
-    <LogSearchShipper data_folder="data" ingestor_host="ingestor.meta.logsearch.io" ingestor_port="443" sessionId="" output_file="test.out">
+    <LogSearchShipper data_folder="data" ingestor_host="ingestor.meta.logsearch.io" ingestor_port="443" sessionId="" output_file="TestOut.log">
       <fileWatchers>
         <watch files="logs\*.*" type="json" sourceTailer="MT">
         </watch>

--- a/src/LogSearchShipper/app.config
+++ b/src/LogSearchShipper/app.config
@@ -11,7 +11,7 @@
 	</configSections>
 	<LogSearchShipperGroup>
 		<LogSearchShipper data_folder="data" ingestor_host="ingestor.meta.logsearch.io" ingestor_port="443"
-                      shipper_service_username="" shipper_service_password="">
+                      shipper_service_username="" shipper_service_password="" output_file="TestOut.log">
 
 			<fileWatchers>
 				<!--				<watch files="\\\\PKH-PPE-WEB24\\Logs\\IIS\\W3SVC1\\u_ex*.log" type="iis_default">-->

--- a/src/LogSearchShipper/app.config
+++ b/src/LogSearchShipper/app.config
@@ -11,7 +11,7 @@
 	</configSections>
 	<LogSearchShipperGroup>
 		<LogSearchShipper data_folder="data" ingestor_host="ingestor.meta.logsearch.io" ingestor_port="443"
-                      shipper_service_username="" shipper_service_password="" output_file="TestOut.log">
+                      shipper_service_username="" shipper_service_password="">
 
 			<fileWatchers>
 				<!--				<watch files="\\\\PKH-PPE-WEB24\\Logs\\IIS\\W3SVC1\\u_ex*.log" type="iis_default">-->

--- a/src/MtLogTailer/FileUtil.cs
+++ b/src/MtLogTailer/FileUtil.cs
@@ -10,14 +10,17 @@ namespace MtLogTailer
 	{
 		// Simple detection of stream encoding
 		// see also http://stackoverflow.com/questions/4520184/how-to-detect-the-character-encoding-of-a-text-file
-		public static Encoding DetectEncoding(Stream stream)
+		public static Encoding DetectEncoding(Stream stream, Encoding defaultEncoding)
 		{
 			var startPosition = stream.Position;
 
 			var bom = new byte[4];
 			var bytesRead = stream.Read(bom, 0, 4);
 			if (bytesRead < bom.Length)
+			{
+				stream.Position = startPosition;
 				return null;
+			}
 
 			if (bom[0] == 0x2b && bom[1] == 0x2f && bom[2] == 0x76)
 			{
@@ -44,44 +47,9 @@ namespace MtLogTailer
 			if (bom[0] == 0 && bom[1] == 0 && bom[2] == 0xfe && bom[3] == 0xff)
 				return Encoding.UTF32;
 
-			// UTF-8 without BOM can give false positives
-			var encoding = Encoding.UTF8;
-			var nonAsciiCharsFound = 0;
-			try
-			{
-				var bufStream = new BufferedStream(stream);
-				var reader = new BinaryReader(bufStream, encoding);
-				while (true)
-				{
-					var ch = reader.Read();
-					if (ch == -1)
-						break;
-					if (ch == (char)0xFFFD)
-					{
-						encoding = Encoding.Default;
-						break;
-					}
-					if (ch > 0x80)
-						nonAsciiCharsFound++;
-					if (nonAsciiCharsFound > 16)
-						break;
-				}
-			}
-			catch (ArgumentOutOfRangeException)
-			{
-				encoding = Encoding.Default;
-			}
-			catch (ArgumentException)
-			{
-				encoding = Encoding.Default;
-			}
-			catch (EndOfStreamException)
-			{
-				encoding = Encoding.Default;
-			}
-
 			stream.Position = startPosition;
-			return encoding;
+
+			return defaultEncoding;
 		}
 	}
 }

--- a/src/MtLogTailer/LogShipper.cs
+++ b/src/MtLogTailer/LogShipper.cs
@@ -12,6 +12,8 @@ namespace MtLogTailer
 	{
 		public LogShipper(string filePath, int defaultEncoding, bool readFromLast)
 		{
+			Program.Log(LogLevel.Info, "LogShipper(). Path: {0}", filePath);
+
 			_filePath = filePath;
 			_defaultEncoding = defaultEncoding;
 			_readFromLast = readFromLast;
@@ -30,6 +32,8 @@ namespace MtLogTailer
 			var newLastWriteTime = GetLastWriteTime();
 			if (newLastWriteTime > _lastWriteTime)
 			{
+				Program.Log(LogLevel.Info, "File '{0}' has changed. Processing...", _filePath);
+
 				using (var stream = OpenStream())
 				{
 					stream.Position = _offset;
@@ -96,7 +100,10 @@ namespace MtLogTailer
 					// check if this is a UTF-8 "The output char buffer is too small" exception
 					// (happening occasionally when only a part of UTF-8 char was flushed to the file)
 					if (exc.ParamName == "chars" && Equals(_encoding, Encoding.UTF8))
+					{
+						Program.Log(LogLevel.Warn, "File '{0}': incomplete UTF8 char in the log ending is detected. Re-try later.", _filePath);
 						break;
+					}
 					else
 					{
 						var message = FormatEncodingMessage(stream, reader, startPosition);
@@ -192,6 +199,8 @@ namespace MtLogTailer
 			{
 				_offset = FindEndOffset(stream);
 			}
+
+			Program.Log(LogLevel.Info, "LogShipper.UpdateCurOffset() done. File '{0}', offset: {1}", _filePath, _offset);
 		}
 
 		private void EnsureInitDone()
@@ -209,6 +218,8 @@ namespace MtLogTailer
 				_startOffset = stream.Position;
 				_offset = _startOffset;
 			}
+
+			Program.Log(LogLevel.Info, "LogShipper.Init() done. File '{0}', encoding: {1}, start offset: {2}", _filePath, Encoding.WebName, _startOffset);
 
 			_initDone = true;
 		}

--- a/src/MtLogTailer/LogShipper.cs
+++ b/src/MtLogTailer/LogShipper.cs
@@ -32,10 +32,11 @@ namespace MtLogTailer
 			var newLastWriteTime = GetLastWriteTime();
 			if (newLastWriteTime > _lastWriteTime)
 			{
-				Program.Log(LogLevel.Info, "File '{0}' has changed. Processing...", _filePath);
-
 				using (var stream = OpenStream())
 				{
+					Program.Log(LogLevel.Info, "File '{0}' has changed. Current offset: {1}, previous last write time {2}, file length {3}. Processing...",
+						_filePath, _offset, _lastWriteTime.ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ"), stream.Length);
+
 					stream.Position = _offset;
 
 					ShipLogData(stream);
@@ -143,7 +144,7 @@ namespace MtLogTailer
 			var message = string.Format(
 				"Error when reading a char. File '{0}', encoding '{1}', started at {2}, ended at {3}, " +
 				"total length {4}, bytes {5}.",
-				_filePath, _encoding.WebName, startPosition, curPosition, stream.Length,
+				_filePath, _encoding.EncodingName, startPosition, curPosition, stream.Length,
 				Convert.ToBase64String(bytes));
 			return message;
 		}

--- a/src/MtLogTailer/LogShipper.cs
+++ b/src/MtLogTailer/LogShipper.cs
@@ -48,7 +48,7 @@ namespace MtLogTailer
 
 		private void ShipLogData(Stream stream)
 		{
-			var reader = new BinaryReader(stream, Encoding);
+			var reader = new BinaryReader(stream, _encoding);
 			var buf = new StringBuilder();
 
 			// read the rest of an incomplete line at the start, if any
@@ -210,16 +210,15 @@ namespace MtLogTailer
 
 			using (var stream = OpenStream())
 			{
-				_encoding = FileUtil.DetectEncoding(stream);
+				_encoding = FileUtil.DetectEncoding(stream, Encoding.GetEncoding(_defaultEncoding));
 				if (_encoding == null)
 					return;
-				if (Equals(_encoding, Encoding.Default))
-					_encoding = null;
+
 				_startOffset = stream.Position;
 				_offset = _startOffset;
 			}
 
-			Program.Log(LogLevel.Info, "LogShipper.Init() done. File '{0}', encoding: {1}, start offset: {2}", _filePath, Encoding.WebName, _startOffset);
+			Program.Log(LogLevel.Info, "LogShipper.Init() done. File '{0}', encoding: {1}, start offset: {2}", _filePath, _encoding.WebName, _startOffset);
 
 			_initDone = true;
 		}
@@ -237,11 +236,6 @@ namespace MtLogTailer
 		long _offset;
 		DateTime _lastWriteTime;
 		private bool _isFirstLine = true;
-
-		public Encoding Encoding
-		{
-			get { return _encoding ?? Encoding.GetEncoding(_defaultEncoding); }
-		}
 
 		private Encoding _encoding;
 		private readonly int _defaultEncoding;

--- a/src/MtLogTailer/Program.cs
+++ b/src/MtLogTailer/Program.cs
@@ -64,11 +64,11 @@ namespace MtLogTailer
 			throw new ApplicationException("Invalid args. Should use MtLogTailer.exe <filePath> (-encoding:int)? (-readFromLast:bool)?");
 		}
 
-		static void LogErrorFormat(string format, params object[] args)
+		public static void Log(LogLevel level, string format, params object[] args)
 		{
 			try
 			{
-				var message = string.Format("{0} {1} {2}", FormatTime(), _version, string.Format(format, args));
+				var message = string.Format("{0}\t{1}\t{2}\t{3}", level.ToString().ToUpperInvariant(), FormatTime(), _version, string.Format(format, args));
 				Console.WriteLine(message);
 			}
 			catch (Exception exc)
@@ -84,7 +84,7 @@ namespace MtLogTailer
 
 		public static void LogError(string message)
 		{
-			LogErrorFormat(Escape(message));
+			Log(LogLevel.Fatal, Escape(message));
 			Environment.Exit(-1);
 		}
 
@@ -103,4 +103,6 @@ namespace MtLogTailer
 		public static volatile bool Terminate;
 		private static string _version;
 	}
+
+	public enum LogLevel { Debug, Info, Warn, Error, Fatal }
 }

--- a/src/MtLogTailer/Program.cs
+++ b/src/MtLogTailer/Program.cs
@@ -14,6 +14,7 @@ namespace MtLogTailer
 		{
 			try
 			{
+				Log(LogLevel.Info, "Starting MT4 tailer process");
 				InitLogging();
 
 				var argsDic = CommandLineUtil.ParseArgs(args);
@@ -35,6 +36,7 @@ namespace MtLogTailer
 
 				Console.OutputEncoding = Encoding.UTF8;
 
+				Log(LogLevel.Info, "path: {0}, readFromLast: {1}, default encoding: {2}", path, readFromLast, encoding);
 				var watcher = new PathWatcher(path, encoding, readFromLast);
 
 				Console.CancelKeyPress +=


### PR DESCRIPTION
This pull request addresses issue #109 (interruptions of MT4 messages shipping, happening occasionally).
The reason turned out to be in a bug in the DetectEncoding() method, which was leading to false detection of UTF-8 encoding sometimes, when the source file was actually in ASCII encoding. (and thus leading to cryptic errors, when trying to decode the file as UTF-8).

+added some diagnostic logging to show what encodings are detected and what's happening when source files change.